### PR TITLE
Add ign tools metadata to -dev install file

### DIFF
--- a/ubuntu/debian/libignition-plugin-dev.install
+++ b/ubuntu/debian/libignition-plugin-dev.install
@@ -2,4 +2,6 @@ usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/ignition-plugin*/*
+usr/lib/ruby/ignition/*
+usr/share/ignition/*
 usr/share/ignition/*/*


### PR DESCRIPTION
The metadata hasn't been updated since https://github.com/ignitionrobotics/ign-plugin/pull/32 was merged, so the nightly builds are unstable.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-plugin2-debbuilder&build=203)](https://build.osrfoundation.org/job/ign-plugin2-debbuilder/203/) https://build.osrfoundation.org/job/ign-plugin2-debbuilder/203/